### PR TITLE
refactor: remove unused logs and standardize form error handling

### DIFF
--- a/internal/handler/middleware/authorizer.go
+++ b/internal/handler/middleware/authorizer.go
@@ -105,14 +105,12 @@ func GetCSRFToken(r *http.Request) string {
 	if token, ok := r.Context().Value(CSRFTokenKey).(string); ok {
 		return token
 	}
-	log.Printf("CSRF token not found in context")
 	return ""
 }
 
 func Auth(r *http.Request) *models.User {
 	user_email, ok := r.Context().Value(UserEmailKey).(string)
 	if !ok {
-		log.Printf("User email not found in context")
 		return nil
 	}
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -182,8 +182,6 @@ func (tr *TemplateRendererImpl) enrichData(w http.ResponseWriter, r *http.Reques
 	// Get CSRF token from context
 	if csrfToken := middleware.GetCSRFToken(r); csrfToken != "" {
 		data["csrf_token"] = csrfToken
-	} else {
-		log.Printf("CSRF token não encontrado no contexto")
 	}
 
 	// Get user from context
@@ -192,8 +190,6 @@ func (tr *TemplateRendererImpl) enrichData(w http.ResponseWriter, r *http.Reques
 		if user.CSRFToken != "" {
 			data["csrf_token"] = user.CSRFToken
 		}
-	} else {
-		log.Printf("Usuário não encontrado no contexto")
 	}
 
 	// Get subscription data from context

--- a/web/pages/auth/forget-password.html
+++ b/web/pages/auth/forget-password.html
@@ -28,7 +28,7 @@
           {{end}}
           <!-- Form -->
           <form method="POST">
-            {{ template "notifications" .}}
+            {{ template "form-errors" .}}
             <input
                 type="hidden"
                 name="csrf_token"

--- a/web/pages/auth/login.html
+++ b/web/pages/auth/login.html
@@ -28,7 +28,7 @@
 
                     <!-- Form -->
                     <form method="post" action="/login">
-                        {{ template "notifications" .}}
+                        {{ template "form-errors" .}}
                         <input
                             type="hidden"
                             name="csrf_token"

--- a/web/pages/auth/reset-password.html
+++ b/web/pages/auth/reset-password.html
@@ -19,7 +19,7 @@
           </div>
           <!-- Form -->
           <form method="POST">
-            {{ template "notifications" .}}
+            {{ template "form-errors" .}}
             <input
                 type="hidden"
                 name="csrf_token"

--- a/web/pages/ebook/index.html
+++ b/web/pages/ebook/index.html
@@ -57,7 +57,6 @@
                   <th scope="col" class="border-0">Valor</th>
                   <th scope="col" class="border-0">Status</th>
                   <th scope="col" class="border-0">Estatísticas</th>
-                  <th scope="col" class="border-0">Data Criação</th>
                   <th scope="col" class="border-0 text-end">Ações</th>
                 </tr>
               </thead>


### PR DESCRIPTION
- Removed context-based log messages for missing CSRF tokens and user emails.
- Replaced `notifications` template usage with `form-errors` in multiple form views.
- Updated error handling to use a consistent `form-error` flash message key.
- Introduced helper methods for persisting and retrieving form data from the session.
- Adjusted templates and views to include better form data handling for user experience.